### PR TITLE
Add two ServerHubs to default config

### DIFF
--- a/BeatSaberMultiplayer/Misc/Config.cs
+++ b/BeatSaberMultiplayer/Misc/Config.cs
@@ -46,7 +46,7 @@ namespace BeatSaberMultiplayer {
             },
             {
                 "0.6.5.0",
-                new string[] { "bs.tigersserver.xyz", "robinsamse.dk", "bbbear-wgzeyu.gtxcn.com", "bs-zhm.tk" }
+                new string[] { "bs.tigersserver.xyz", "robinsamse.dk", "bbbear-wgzeyu.gtxcn.com", "bs-zhm.tk", "beatsaber.freddi.xyz" }
             }
         };
 

--- a/BeatSaberMultiplayer/Misc/Config.cs
+++ b/BeatSaberMultiplayer/Misc/Config.cs
@@ -46,7 +46,7 @@ namespace BeatSaberMultiplayer {
             },
             {
                 "0.6.5.0",
-                new string[] { "bs.tigersserver.xyz", "robinsamse.dk" }
+                new string[] { "bs.tigersserver.xyz", "robinsamse.dk", "bbbear-wgzeyu.gtxcn.com", "bs-zhm.tk" }
             }
         };
 

--- a/BeatSaberMultiplayer/Properties/AssemblyInfo.cs
+++ b/BeatSaberMultiplayer/Properties/AssemblyInfo.cs
@@ -15,5 +15,5 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("19e76954-2eba-4761-8ad4-1425cc29ec0e")]
 
-[assembly: AssemblyVersion("0.7.0.0")]
-[assembly: AssemblyFileVersion("0.7.0.0")]
+[assembly: AssemblyVersion("0.6.5.0")]
+[assembly: AssemblyFileVersion("0.6.5.0")]

--- a/BeatSaberMultiplayer/UI/ViewControllers/CreateRoomScreen/RoomCreationServerHubsListViewController.cs
+++ b/BeatSaberMultiplayer/UI/ViewControllers/CreateRoomScreen/RoomCreationServerHubsListViewController.cs
@@ -62,7 +62,7 @@ namespace BeatSaberMultiplayer.UI.ViewControllers.CreateRoomScreen
                     _pageDownButton = Instantiate(Resources.FindObjectsOfTypeAll<Button>().First(x => (x.name == "PageDownButton")), rectTransform, false);
                     (_pageDownButton.transform as RectTransform).anchorMin = new Vector2(0.5f, 0f);
                     (_pageDownButton.transform as RectTransform).anchorMax = new Vector2(0.5f, 0f);
-                    (_pageDownButton.transform as RectTransform).anchoredPosition = new Vector2(0f, 9f);
+                    (_pageDownButton.transform as RectTransform).anchoredPosition = new Vector2(0f, 0f);
                     (_pageDownButton.transform as RectTransform).sizeDelta = new Vector2(40f, 10f);
                     _pageDownButton.interactable = true;
                     _pageDownButton.onClick.AddListener(delegate ()

--- a/BeatSaberMultiplayer/UI/ViewControllers/RoomScreen/SongSelectionViewController.cs
+++ b/BeatSaberMultiplayer/UI/ViewControllers/RoomScreen/SongSelectionViewController.cs
@@ -132,7 +132,7 @@ namespace BeatSaberMultiplayer.UI.ViewControllers.RoomScreen
                 _fastPageDownButton = Instantiate(Resources.FindObjectsOfTypeAll<Button>().First(x => (x.name == "PageDownButton")), rectTransform, false);
                 (_fastPageDownButton.transform as RectTransform).anchorMin = new Vector2(0.5f, 0f);
                 (_fastPageDownButton.transform as RectTransform).anchorMax = new Vector2(0.5f, 0f);
-                (_fastPageDownButton.transform as RectTransform).anchoredPosition = new Vector2(-26f, 7f);
+                (_fastPageDownButton.transform as RectTransform).anchoredPosition = new Vector2(-26f, 0f);
                 (_fastPageDownButton.transform as RectTransform).sizeDelta = new Vector2(8f, 6f);
                 _fastPageDownButton.GetComponentsInChildren<RectTransform>().First(x => x.name == "BG").sizeDelta = new Vector2(8f, 6f);
                 _fastPageDownButton.GetComponentsInChildren<Image>().First(x => x.name == "Arrow").sprite = Sprites.doubleArrow;
@@ -157,7 +157,7 @@ namespace BeatSaberMultiplayer.UI.ViewControllers.RoomScreen
                 _pageDownButton = Instantiate(Resources.FindObjectsOfTypeAll<Button>().First(x => (x.name == "PageDownButton")), rectTransform, false);
                 (_pageDownButton.transform as RectTransform).anchorMin = new Vector2(0.5f, 0f);
                 (_pageDownButton.transform as RectTransform).anchorMax = new Vector2(0.5f, 0f);
-                (_pageDownButton.transform as RectTransform).anchoredPosition = new Vector2(0f, 7f);
+                (_pageDownButton.transform as RectTransform).anchoredPosition = new Vector2(0f, 0f);
                 (_pageDownButton.transform as RectTransform).sizeDelta = new Vector2(40f, 6f);
                 _pageDownButton.onClick.AddListener(delegate ()
                 {

--- a/BeatSaberMultiplayer/manifest.json
+++ b/BeatSaberMultiplayer/manifest.json
@@ -8,14 +8,14 @@
     "name": "Beat Saber Multiplayer",
     "version": "0.6.5.2",
     "dependsOn": {
-        "CustomUI": "^1.5.11",
-        "Custom Avatars": "^4.7.3",
-        "BS Utils": "^1.3.6",
-        "SongCore": "^2.0.9"
+        "CustomUI": "^1.7.1",
+        "Custom Avatars": "^4.7.7",
+        "BS Utils": "^1.3.7",
+        "SongCore": "^2.4.1"
     },
     "loadAfter": [],
     "links": {
-        "project-source": "https://github.com/andruzzzhka/BeatSaberMultiplayer",
+        "project-source": "https://github.com/wgzeyu/BeatSaberMultiplayer",
         "donate": "https://ko-fi.com/andruzzzhka"
     },
     "features": []

--- a/BeatSaberMultiplayer/manifest.json
+++ b/BeatSaberMultiplayer/manifest.json
@@ -6,7 +6,7 @@
     "icon": "BeatSaberMultiplayer.Assets.OnlineIcon.png",
     "id": "BeatSaberMultiplayer",
     "name": "Beat Saber Multiplayer",
-    "version": "0.6.5.2",
+    "version": "0.6.5.3",
     "dependsOn": {
         "CustomUI": "^1.7.1",
         "Custom Avatars": "^4.7.7",

--- a/BeatSaberMultiplayer/manifest.json
+++ b/BeatSaberMultiplayer/manifest.json
@@ -2,11 +2,11 @@
     "$schema": "https://github.com/nike4613/BSIPA-MetadataFileSchema/master/Schema.json",
     "author": "andruzzzhka",
     "description": "Allows you to play with friends online!",
-    "gameVersion": "1.3.0",
+    "gameVersion": "1.5.0",
     "icon": "BeatSaberMultiplayer.Assets.OnlineIcon.png",
     "id": "BeatSaberMultiplayer",
     "name": "Beat Saber Multiplayer",
-    "version": "0.6.5.1",
+    "version": "0.6.5.2",
     "dependsOn": {
         "CustomUI": "^1.5.11",
         "Custom Avatars": "^4.7.3",

--- a/BeatSaberMultiplayer/manifest.json
+++ b/BeatSaberMultiplayer/manifest.json
@@ -6,7 +6,7 @@
     "icon": "BeatSaberMultiplayer.Assets.OnlineIcon.png",
     "id": "BeatSaberMultiplayer",
     "name": "Beat Saber Multiplayer",
-    "version": "0.6.5.3",
+    "version": "0.6.5.4",
     "dependsOn": {
         "CustomUI": "^1.7.1",
         "Custom Avatars": "^4.7.7",

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# Latest version: 0.6.5.1
-# [Plugin Releases](https://github.com/superrob/BeatSaberMultiplayer/releases/)
+# Latest version: 0.6.5.2
+# [Plugin Releases](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/)
 # [WebRCON](https://andruzzzhka.github.io/BeatSaberMultiplayer/)
-## Client 0.6.5.1:
+## Client 0.6.5.2:
 [Guide](https://bs.assistant.moe/Multiplayer/#Install) by Assistant#8431
 
-[Universal](https://github.com/superrob/BeatSaberMultiplayer/releases/download/0.6.5.1/BeatSaberMultiplayer.zip)
+[Universal](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/download/0.6.5.2/BeatSaberMultiplayer.zip)
 
 
 
 ## ServerHub 0.6.5.0:
 [Guide](https://bs.assistant.moe/Multiplayer/#Hub) by Assistant#8431
 
-[Windows](https://github.com/superrob/BeatSaberMultiplayer/releases/download/0.6.5.1/ServerHub_win-64.zip)
+[Windows](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/download/0.6.5.2/ServerHub_win-64.zip)
 
-[Linux-64bit](https://github.com/superrob/BeatSaberMultiplayer/releases/download/0.6.5.1/ServerHub_linux-64.zip)
+[Linux-64bit](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/download/0.6.5.2/ServerHub_linux-64.zip)
 
-[Linux-Arm](https://github.com/superrob/BeatSaberMultiplayer/releases/download/0.6.5.1/ServerHub_linux-arm.zip)
+[Linux-Arm](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/download/0.6.5.2/ServerHub_linux-arm.zip)
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# Latest version: 0.6.5.3
+# Latest version: 0.6.5.4
 # [Plugin Releases](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/)
 # [WebRCON](https://andruzzzhka.github.io/BeatSaberMultiplayer/)
-## Client 0.6.5.3:
+## Client 0.6.5.4:
 [Guide](https://bs.assistant.moe/Multiplayer/#Install) by Assistant#8431
 
-[Universal](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/download/0.6.5.3/BeatSaberMultiplayer.zip)
+[Universal](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/download/0.6.5.4/BeatSaberMultiplayer.zip)
 
 
 
 ## ServerHub 0.6.5.0:
 [Guide](https://bs.assistant.moe/Multiplayer/#Hub) by Assistant#8431
 
-[Windows](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/download/0.6.5.3/ServerHub_win-64.zip)
+[Windows](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/download/0.6.5.4/ServerHub_win-64.zip)
 
-[Linux-64bit](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/download/0.6.5.3/ServerHub_linux-64.zip)
+[Linux-64bit](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/download/0.6.5.4/ServerHub_linux-64.zip)
 
-[Linux-Arm](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/download/0.6.5.3/ServerHub_linux-arm.zip)
+[Linux-Arm](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/download/0.6.5.4/ServerHub_linux-arm.zip)
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# Latest version: 0.6.5.2
+# Latest version: 0.6.5.3
 # [Plugin Releases](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/)
 # [WebRCON](https://andruzzzhka.github.io/BeatSaberMultiplayer/)
-## Client 0.6.5.2:
+## Client 0.6.5.3:
 [Guide](https://bs.assistant.moe/Multiplayer/#Install) by Assistant#8431
 
-[Universal](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/download/0.6.5.2/BeatSaberMultiplayer.zip)
+[Universal](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/download/0.6.5.3/BeatSaberMultiplayer.zip)
 
 
 
 ## ServerHub 0.6.5.0:
 [Guide](https://bs.assistant.moe/Multiplayer/#Hub) by Assistant#8431
 
-[Windows](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/download/0.6.5.2/ServerHub_win-64.zip)
+[Windows](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/download/0.6.5.3/ServerHub_win-64.zip)
 
-[Linux-64bit](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/download/0.6.5.2/ServerHub_linux-64.zip)
+[Linux-64bit](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/download/0.6.5.3/ServerHub_linux-64.zip)
 
-[Linux-Arm](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/download/0.6.5.2/ServerHub_linux-arm.zip)
+[Linux-Arm](https://github.com/wgzeyu/BeatSaberMultiplayer/releases/download/0.6.5.3/ServerHub_linux-arm.zip)
 


### PR DESCRIPTION
At present, these ServerHubs are almost all running in Europe and North America, and the latency from Asia is very high. At the same time, due to the long-term congestion of international Internet exports in China, connecting these ServerHubs in China is very unstable.
So my friends and I have set up ServerHub in China and plan to run it for a long time, so I added it to the default configuration to optimize the online experience in China and even Asia.
I have contacted Assistant and these servers have been added to Guide.

server:
bbbear-wgzeyu.gtxcn.com:3700
bs-zhm.tk:3700

landing page:
https://bbbear-wgzeyu.gtxcn.com/
https://ws.bs-zhm.tk/